### PR TITLE
Add method signature for station.shareStation and user.startComplimentaryTrial, as well as an error code

### DIFF
--- a/json/account.rst
+++ b/json/account.rst
@@ -224,3 +224,20 @@ The request has no parameters.
         }
     }
 
+
+.. index::
+   pair: method; user.startComplimentaryTrial
+    
+.. _user-startComplimentaryTrial:
+
+Start a Complimentary Trial
+---------------------------
+
+:Method: user.startComplimentaryTrial
+
+Starts a complimentary pandora one trial. It is unknown what constitutes a valid sponsor at this time, and as such this method will always fail.
+
+.. csv-table::
+    :header: Name,Type,Description
+    
+    complimentarySponsor,string,The ID of the sponsor providing the complimentary trial.

--- a/json/errorcodes.rst
+++ b/json/errorcodes.rst
@@ -54,5 +54,5 @@ Code  Description
 1035     DAILY_TRIAL_LIMIT_REACHED         
 1036     INVALID_SPONSOR         
 1037     USER_ALREADY_USED_TRIAL 
+1039     PLAYLIST_EXCEEDED      Too many requests for a new playlist
 ====  ============
-

--- a/json/stations.rst
+++ b/json/stations.rst
@@ -568,6 +568,26 @@ See :ref:`user-getStationListChecksum`.
 
 
 .. index::
+   pair: method; station.shareStation
+
+.. _station-shareStation:
+
+Share Station
+-------------
+
+:Method: station.shareStation
+
+Shares a station with the specified email addresses. that emails is a string array
+
+.. csv-table::
+    :header: Name ,Type ,Description
+    
+    stationId,string,See :ref:`user-getStationList`
+    stationToken,string,See :ref:`user-getStationList`
+    emails,string[],A list of emails to share the station with   
+
+
+.. index::
    pair: method; station.transformSharedStation
 
 .. _station-transformSharedStation:
@@ -610,4 +630,3 @@ Modify QuickMix
     }
 
 The response contains no data.
-


### PR DESCRIPTION
Add method signature for station.shareStation and user.startComplimentaryTrial, as well as an error code. I had this from when I was building my library back when the wikia was up. Not sure if these are still accurate or if the API has changed at all since a few months ago.
