### PR TITLE
docs:Add details on different search result token formats.

### DIFF
--- a/json/stations.rst
+++ b/json/stations.rst
@@ -156,8 +156,8 @@ Matching songs and artists are returned in two separate list.
 .. csv-table::
     :header: Name ,Type ,Description
 
-    songs.musicToken ,string , 'S' followed by seven digits (e.g. 'S1234567')
-    artists.musicToken ,string , Results can be either for artists ('R' followed by six digits) or composers ('C' followed by five digits).
+    songs.musicToken ,string , Starts with 'S' followed by one or more digits (e.g. 'S1234567')
+    artists.musicToken ,string , Results can be either for artists (starts with 'R') or composers (starts with 'C').
 
 .. code:: json
 

--- a/json/stations.rst
+++ b/json/stations.rst
@@ -156,7 +156,8 @@ Matching songs and artists are returned in two separate list.
 .. csv-table::
     :header: Name ,Type ,Description
 
-    songs.musicToken and artists.musicToken ,string ,
+    songs.musicToken ,string , 'S' followed by seven digits (e.g. 'S1234567')
+    artists.musicToken ,string , Results can be either for artists ('R' followed by six digits) or composers ('C' followed by five digits).
 
 .. code:: json
 


### PR DESCRIPTION
It seems that the ``musicToken`` for search results is divided into three categories:

- song results start with 'S' and are followed by seven digits.
- artist results start with 'R' and are followed by six digits.
- composer results start with 'C' and are followed by five digits.

``nearMatchesAvailable is True`` indicates that more results are available, but they are not included in the ``result`` list. This may suggest that near matches need to be retrieved with a separate (as yet undocumented) call.